### PR TITLE
Multi task create

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const taskbookCLI = (input, flags) => {
   }
 
   if (flags.task) {
-    return taskbook.createTask(input);
+    return taskbook.createTasks(input);
   }
 
   if (flags.restore) {
@@ -16,7 +16,7 @@ const taskbookCLI = (input, flags) => {
   }
 
   if (flags.note) {
-    return taskbook.createNote(input);
+    return taskbook.createNotes(input);
   }
 
   if (flags.delete) {

--- a/lib/help.js
+++ b/lib/help.js
@@ -6,8 +6,8 @@ module.exports = `
 
     Options
         none             Display board view
-      --task, -t         Create task, use :: as a delimiter to create multiple
-      --note, -n         Create note, use :: as a delimiter to create multiple
+      --task, -t         Create task
+      --note, -n         Create note
       --timeline, -i     Display timeline view
       --delete, -d       Delete item
       --check, -c        Check/uncheck task

--- a/lib/help.js
+++ b/lib/help.js
@@ -6,8 +6,8 @@ module.exports = `
 
     Options
         none             Display board view
-      --task, -t         Create task
-      --note, -n         Create note
+      --task, -t         Create task, use :: as a delimiter to create multiple
+      --note, -n         Create note, use :: as a delimiter to create multiple
       --timeline, -i     Display timeline view
       --delete, -d       Delete item
       --check, -c        Check/uncheck task
@@ -27,7 +27,9 @@ module.exports = `
       $ tb --task Make some buttercream
       $ tb --task @coding Improve documentation
       $ tb --task @coding @reviews Review PR #42
+      $ tb --task @shopping bananas::bread::brown sugar
       $ tb --note @coding Mergesort worse-case O(nlogn)
+      $ tb --note @styles red borders::blue underline::black text
       $ tb --check 1 2
       $ tb --delete 4
       $ tb --star 2

--- a/lib/render.js
+++ b/lib/render.js
@@ -242,9 +242,10 @@ class Render {
     error({prefix, message});
   }
 
-  successCreate({_id, _isTask}) {
-    const [prefix, suffix] = ['\n', grey(_id)];
-    const message = `Created ${_isTask ? 'task:' : 'note:'}`;
+  successCreate(ids, areTasks) {
+    const [prefix, suffix] = ['\n', grey(ids.join(', '))];
+    let message = `Created ${areTasks ? 'task' : 'note'}`;
+    message += ids.length > 1 ? 's:' : ':';
     success({prefix, message, suffix});
   }
 

--- a/lib/taskbook.js
+++ b/lib/taskbook.js
@@ -102,7 +102,6 @@ class Taskbook {
       process.exit(1);
     }
 
-    const id = this._generateID();
     const priority = this._getPriority(input);
 
     input.forEach(x => {
@@ -111,13 +110,13 @@ class Taskbook {
       }
     });
 
-    const description = desc.join(' ');
+    const descriptions = desc.join(' ').split('::');
 
     if (boards.length === 0) {
       boards.push('My Board');
     }
 
-    return {boards, description, id, priority};
+    return {boards, descriptions, priority};
   }
 
   _getStats() {
@@ -297,13 +296,21 @@ class Taskbook {
     this._save(_data);
   }
 
-  createNote(desc) {
-    const {id, description, boards} = this._getOptions(desc);
-    const note = new Note({id, description, boards});
+  createNotes(desc) {
+    const {boards, descriptions} = this._getOptions(desc);
+
     const {_data} = this;
-    _data[id] = note;
+    const initialID = this._generateID();
+    const ids = descriptions.map((description, i) => {
+      const id = initialID + i;
+      const note = new Note({id, description, boards});
+      _data[id] = note;
+
+      return id;
+    });
+
     this._save(_data);
-    render.successCreate(note);
+    render.successCreate(ids, false);
   }
 
   checkTasks(ids) {
@@ -318,13 +325,21 @@ class Taskbook {
     render.markComplete(ids);
   }
 
-  createTask(desc) {
-    const {boards, description, id, priority} = this._getOptions(desc);
-    const task = new Task({id, description, boards, priority});
+  createTasks(desc) {
+    const {boards, descriptions, priority} = this._getOptions(desc);
+
     const {_data} = this;
-    _data[id] = task;
+    const initialID = this._generateID();
+    const ids = descriptions.map((description, i) => {
+      const id = initialID + i;
+      const task = new Task({id, description, boards, priority});
+      _data[id] = task;
+
+      return id;
+    });
+
     this._save(_data);
-    render.successCreate(task);
+    render.successCreate(ids, true);
   }
 
   deleteItems(ids) {

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,9 @@ $ tb --help
       $ tb --task Make some buttercream
       $ tb --task @coding Improve documentation
       $ tb --task @coding @reviews Review PR #42
+      $ tb --task @shopping bananas::bread::brown sugar
       $ tb --note @coding Mergesort worse-case O(nlogn)
+      $ tb --note @styles red borders::blue underline::black text
       $ tb --check 1 2
       $ tb --delete 4
       $ tb --star 2
@@ -173,18 +175,20 @@ In case you spotted an error or think that an example is not to clear enough and
 
 ### Create Task
 
-To create a new task use the `--task`/`-t` option with your task's description following right after. 
+To create a new task use the `--task`/`-t` option with your task's description following right after. Create multiple tasks at once by using `::` as a delimiter between task descriptions. Multiple tasks are creating using the same boards and priority specified.
 
 ```
 $ tb -t Improve documentation
+$ tb -t Fix translations::Add validation::Write unit tests
 ```
 
 ### Create Note
 
-To create a new note use the `--note`/`-n` option with your note's body following right after. 
+To create a new note use the `--note`/`-n` option with your note's body following right after. Multiple notes can also be created at once by using `::` as a delimiter between note descriptions. Multiple notes are created using the same boards specified.
 
 ```
 $ tb -n Mergesort worse-case O(nlogn)
+$ tb -n Font size is 16px::Background color is f4f7fb::Margin size is 2rem
 ```
 
 ### Create Board
@@ -230,8 +234,8 @@ $ tb -i
 ### Set Priority
 
 To set a priority level for a task while initializing it, include the `p:x` syntax in the task's description, where x can be an integer of value `1`, `2` or `3`. Note that all tasks by default are created with a normal priority - `1`.
- 
-- `1` - Normal priority 
+
+- `1` - Normal priority
 - `2` - Medium priority
 - `3` - High priority
 
@@ -296,7 +300,7 @@ The by default supported listing attributes, together with their respective alia
 
 ### Search Items
 
-To search for one of more items, use the `--find`/`-f` option, followed by your search terms. 
+To search for one of more items, use the `--find`/`-f` option, followed by your search terms.
 
 ```
 $ tb -f documentation


### PR DESCRIPTION
Pull request to support batch creation of tasks and notes using `::` as a delimiter. Addresses #22 but couldn't use `|` as delimiter without forcing the creator to wrap the whole description in quotations. If a better delimiter is suggested and agreed upon I can quickly switch it out.

### Creating multiple notes
![image](https://user-images.githubusercontent.com/11670266/43986956-45c5a2a0-9cdf-11e8-9d44-f6e28d97798f.png)

### Creating multiple tasks with priority
![image](https://user-images.githubusercontent.com/11670266/43987032-39210e9e-9ce0-11e8-87aa-ffcfd4d922db.png)

### Creating single task
![image](https://user-images.githubusercontent.com/11670266/43987044-53b68a68-9ce0-11e8-983e-83c5aa7c3999.png)