### PR TITLE
Add --begin flag to start/stop progress on tasks

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -40,6 +40,10 @@ const cli = meow(help, {
       type: 'boolean',
       alias: 'c'
     },
+    begin: {
+      type: 'boolean',
+      alias: 'b'
+    },
     star: {
       type: 'boolean',
       alias: 's'

--- a/index.js
+++ b/index.js
@@ -27,6 +27,10 @@ const taskbookCLI = (input, flags) => {
     return taskbook.checkTasks(input);
   }
 
+  if (flags.begin) {
+    return taskbook.beginTasks(input);
+  }
+
   if (flags.star) {
     return taskbook.starItems(input);
   }

--- a/lib/help.js
+++ b/lib/help.js
@@ -7,7 +7,7 @@ module.exports = `
     Options
         none             Display board view
       --archive, -a      Display archived items
-      --begin, -b        Start/stop task
+      --begin, -b        Start/pause task
       --check, -c        Check/uncheck task
       --clear            Delete all checked items
       --copy, -y         Copy item description

--- a/lib/help.js
+++ b/lib/help.js
@@ -7,6 +7,7 @@ module.exports = `
     Options
         none             Display board view
       --archive, -a      Display archived items
+      --begin, -b        Start/stop task
       --check, -c        Check/uncheck task
       --clear            Delete all checked items
       --copy, -y         Copy item description
@@ -27,6 +28,7 @@ module.exports = `
     Examples
       $ tb
       $ tb --archive
+      $ tb --begin 2 3
       $ tb --check 1 2
       $ tb --clear
       $ tb --copy 1 2 3

--- a/lib/render.js
+++ b/lib/render.js
@@ -249,13 +249,13 @@ class Render {
     success({prefix, message, suffix});
   }
 
-  markStopped(ids) {
+  markPaused(ids) {
     if (ids.length === 0) {
       return;
     }
 
     const [prefix, suffix] = ['\n', grey(ids.join(', '))];
-    const message = `Stopped ${ids.length > 1 ? 'tasks' : 'task'}:`;
+    const message = `Paused ${ids.length > 1 ? 'tasks' : 'task'}:`;
     success({prefix, message, suffix});
   }
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -6,6 +6,7 @@ const config = require('./config');
 signale.config({displayLabel: false});
 
 const {error, log, note, pending, success} = signale;
+const awaiting = signale.await; // Avoids "await outside async function" lint error
 const {blue, green, grey, magenta, red, underline, yellow} = chalk;
 
 const priorities = {2: 'yellow', 3: 'red'};
@@ -99,7 +100,7 @@ class Render {
   }
 
   _displayItemByBoard(item) {
-    const {_isTask, isComplete} = item;
+    const {_isTask, isComplete, inProgress} = item;
     const age = this._getAge(item._timestamp);
     const star = this._getStar(item);
 
@@ -110,14 +111,14 @@ class Render {
     const msgObj = {prefix, message, suffix};
 
     if (_isTask) {
-      return isComplete ? success(msgObj) : pending(msgObj);
+      return isComplete ? success(msgObj) : inProgress ? awaiting(msgObj) : pending(msgObj);
     }
 
     return note(msgObj);
   }
 
   _displayItemByDate(item) {
-    const {_isTask, isComplete} = item;
+    const {_isTask, isComplete, inProgress} = item;
     const boards = item.boards.filter(x => x !== 'My Board');
     const star = this._getStar(item);
 
@@ -128,7 +129,7 @@ class Render {
     const msgObj = {prefix, message, suffix};
 
     if (_isTask) {
-      return isComplete ? success(msgObj) : pending(msgObj);
+      return isComplete ? success(msgObj) : inProgress ? awaiting(msgObj) : pending(msgObj);
     }
 
     return note(msgObj);
@@ -168,7 +169,7 @@ class Render {
     });
   }
 
-  displayStats({percent, complete, pending, notes}) {
+  displayStats({percent, complete, inProgress, pending, notes}) {
     if (!this._configuration.displayProgressOverview) {
       return;
     }
@@ -177,15 +178,16 @@ class Render {
 
     const status = [
       `${green(complete)} ${grey('done')}`,
+      `${blue(inProgress)} ${grey('in progress')}`,
       `${magenta(pending)} ${grey('pending')}`,
       `${blue(notes)} ${grey(notes === 1 ? 'note' : 'notes')}`
     ];
 
-    if (complete !== 0 && pending === 0 && notes === 0) {
+    if (complete !== 0 && inProgress === 0 && pending === 0 && notes === 0) {
       log({prefix: '\n ', message: 'All done!', suffix: yellow('★')});
     }
 
-    if (pending + complete + notes === 0) {
+    if (pending + inProgress + complete + notes === 0) {
       log({prefix: '\n ', message: 'Type `tb --help` to get started!', suffix: yellow('★')});
     }
 
@@ -234,6 +236,26 @@ class Render {
 
     const [prefix, suffix] = ['\n', grey(ids.join(', '))];
     const message = `Unchecked ${ids.length > 1 ? 'tasks' : 'task'}:`;
+    success({prefix, message, suffix});
+  }
+
+  markStarted(ids) {
+    if (ids.length === 0) {
+      return;
+    }
+
+    const [prefix, suffix] = ['\n', grey(ids.join(', '))];
+    const message = `Started ${ids.length > 1 ? 'tasks' : 'task'}:`;
+    success({prefix, message, suffix});
+  }
+
+  markStopped(ids) {
+    if (ids.length === 0) {
+      return;
+    }
+
+    const [prefix, suffix] = ['\n', grey(ids.join(', '))];
+    const message = `Stopped ${ids.length > 1 ? 'tasks' : 'task'}:`;
     success({prefix, message, suffix});
   }
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -5,8 +5,7 @@ const config = require('./config');
 
 signale.config({displayLabel: false});
 
-const {error, log, note, pending, success} = signale;
-const awaiting = signale.await; // Avoids "await outside async function" lint error
+const {await: awaiting, error, log, note, pending, success} = signale;
 const {blue, green, grey, magenta, red, underline, yellow} = chalk;
 
 const priorities = {2: 'yellow', 3: 'red'};

--- a/lib/task.js
+++ b/lib/task.js
@@ -6,6 +6,7 @@ class Task extends Item {
     super(options);
     this._isTask = true;
     this.isComplete = options.isComplete || false;
+    this.inProgress = options.inProgress || false;
     this.isStarred = options.isStarred || false;
     this.priority = options.priority || 1;
   }

--- a/lib/taskbook.js
+++ b/lib/taskbook.js
@@ -354,16 +354,16 @@ class Taskbook {
   beginTasks(ids) {
     ids = this._validateIDs(ids);
     const {_data} = this;
-    const [started, stopped] = [[], []];
+    const [started, paused] = [[], []];
 
     ids.forEach(id => {
       _data[id].inProgress = !_data[id].inProgress;
-      return _data[id].inProgress ? started.push(id) : stopped.push(id);
+      return _data[id].inProgress ? started.push(id) : paused.push(id);
     });
 
     this._save(_data);
     render.markStarted(started);
-    render.markStopped(stopped);
+    render.markPaused(paused);
   }
 
   createTask(desc) {

--- a/lib/taskbook.js
+++ b/lib/taskbook.js
@@ -342,6 +342,7 @@ class Taskbook {
     const [checked, unchecked] = [[], []];
 
     ids.forEach(id => {
+      _data[id].inProgress = false;
       _data[id].isComplete = !_data[id].isComplete;
       return _data[id].isComplete ? checked.push(id) : unchecked.push(id);
     });
@@ -357,6 +358,7 @@ class Taskbook {
     const [started, paused] = [[], []];
 
     ids.forEach(id => {
+      _data[id].isComplete = false;
       _data[id].inProgress = !_data[id].inProgress;
       return _data[id].inProgress ? started.push(id) : paused.push(id);
     });

--- a/lib/taskbook.js
+++ b/lib/taskbook.js
@@ -123,11 +123,11 @@ class Taskbook {
 
   _getStats() {
     const {_data} = this;
-    let [complete, pending, notes] = [0, 0, 0];
+    let [complete, inProgress, pending, notes] = [0, 0, 0, 0];
 
     Object.keys(_data).forEach(id => {
       if (_data[id]._isTask) {
-        return _data[id].isComplete ? complete++ : pending++;
+        return _data[id].isComplete ? complete++ : _data[id].inProgress ? inProgress++ : pending++;
       }
 
       return notes++;
@@ -136,7 +136,7 @@ class Taskbook {
     const total = complete + pending;
     const percent = (total === 0) ? 0 : Math.floor(complete * 100 / total);
 
-    return {percent, complete, pending, notes};
+    return {percent, complete, inProgress, pending, notes};
   }
 
   _hasTerms(string, terms) {
@@ -163,6 +163,15 @@ class Taskbook {
   _filterStarred(data) {
     Object.keys(data).forEach(id => {
       if (!data[id].isStarred) {
+        delete data[id];
+      }
+    });
+    return data;
+  }
+
+  _filterInProgress(data) {
+    Object.keys(data).forEach(id => {
+      if (!data[id]._isTask || !data[id].inProgress) {
         delete data[id];
       }
     });
@@ -212,6 +221,12 @@ class Taskbook {
         case 'checked':
         case 'complete':
           data = this._filterComplete(data);
+          break;
+
+        case 'progress':
+        case 'started':
+        case 'begun':
+          data = this._filterInProgress(data);
           break;
 
         case 'pending':
@@ -334,6 +349,21 @@ class Taskbook {
     this._save(_data);
     render.markComplete(checked);
     render.markIncomplete(unchecked);
+  }
+
+  beginTasks(ids) {
+    ids = this._validateIDs(ids);
+    const {_data} = this;
+    const [started, stopped] = [[], []];
+
+    ids.forEach(id => {
+      _data[id].inProgress = !_data[id].inProgress;
+      return _data[id].inProgress ? started.push(id) : stopped.push(id);
+    });
+
+    this._save(_data);
+    render.markStarted(started);
+    render.markStopped(stopped);
   }
 
   createTask(desc) {

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ $ tb --help
     Options
         none             Display board view
       --archive, -a      Display archived items
-      --begin, -b        Start/stop task
+      --begin, -b        Start/pause task
       --check, -c        Check/uncheck task
       --clear            Delete all checked items
       --copy, -y         Copy item description
@@ -222,7 +222,7 @@ $ tb -c 1 3
 
 ### Begin Task
 
-To mark a task as started/stopped, use the `--begin`/`-b` option followed by the ids of the target tasks. The functionality of this option is the same as the one of the above described `--check` option.
+To mark a task as started/paused, use the `--begin`/`-b` option followed by the ids of the target tasks. The functionality of this option is the same as the one of the above described `--check` option.
 
 ```
 $ tb -b 2 3

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ $ tb --help
     Options
         none             Display board view
       --archive, -a      Display archived items
+      --begin, -b        Start/stop task
       --check, -c        Check/uncheck task
       --clear            Delete all checked items
       --copy, -y         Copy item description
@@ -106,6 +107,7 @@ $ tb --help
     Examples
       $ tb
       $ tb --archive
+      $ tb --begin 2 3
       $ tb --check 1 2
       $ tb --clear
       $ tb --copy 1 2 3
@@ -218,6 +220,14 @@ To mark a task as complete/incomplete, use the `--check`/`-c` option followed by
 $ tb -c 1 3
 ```
 
+### Begin Task
+
+To mark a task as started/stopped, use the `--begin`/`-b` option followed by the ids of the target tasks. The functionality of this option is the same as the one of the above described `--check` option.
+
+```
+$ tb -b 2 3
+```
+
 ### Star Item
 
 To mark one or more items as favorite, use the `--star`/`-s` option followed by the ids of the target items. The functionality of this option is the same as the one of the above described `--check` option.
@@ -322,6 +332,7 @@ The by default supported listing attributes, together with their respective alia
 - `task`, `tasks`, `todo` - Items that are tasks.
 - `note`, `notes` - Items that are notes.
 - `pending`, `unchecked`, `incomplete` - Items that are pending tasks.
+- `progress`, `started`, `begun` - Items that are in-progress tasks.
 - `done`, `checked`, `complete` - Items that complete tasks.
 - `star`, `starred` - Items that are starred.
 


### PR DESCRIPTION
This PR adds a `--begin` flag to mark tasks as "in progress." This should resolve #92.

I chose `--begin` because `-b` is available as a shorthand and because I couldn't think of a verb like check/uncheck or star/unstar. Tasks in progress are rendered using `signale.await`, which displays a blue ellipsis (…). Let me know if a custom signal should be added, since notes also use blue and the ellipsis might not be intuitive.

Here's what the usage looks like right now:
<img width="383" alt="screen shot 2018-10-14 at 21 26 44" src="https://user-images.githubusercontent.com/2885412/46930004-ea534e80-cff7-11e8-9d76-5e9120233984.png">

And here's the list command (with support for "progress", "started", and "begun"):
<img width="383" alt="screen shot 2018-10-14 at 21 27 45" src="https://user-images.githubusercontent.com/2885412/46930032-0c4cd100-cff8-11e8-88cd-c07a2a713d7e.png">