### PR TITLE
Normalize case before searching.

### DIFF
--- a/lib/taskbook.js
+++ b/lib/taskbook.js
@@ -142,7 +142,7 @@ class Taskbook {
     let result;
 
     terms.forEach((term, key, arr) => {
-      if (string.toLowerCase().indexOf(term) > -1) {
+      if (string.toLocaleLowerCase().indexOf(term.toLocaleLowerCase()) > -1) {
         result = (key === arr.length - 1) ? string : '';
       }
     });


### PR DESCRIPTION
Fixes #110

I am using `toLocaleLowerCase()` vs `toLowerCase()` as I found it recommended for international support (Turkish language examples in MDN documenation).  If there is any reason to prefer `toLowerCase()`, please let me know and I will update the pull request 

Test Case (Same results for both searches):
```
tb -t Create Jira ticket
tb -f Jira
tb -f jira
```

