### PR TITLE
[Feat] Filter by priority

### DIFF
--- a/src/taskbook.js
+++ b/src/taskbook.js
@@ -201,6 +201,16 @@ class Taskbook {
     return data;
   }
 
+  _filterPriority(data, attr) {
+    const priority = parseInt(attr.replace(/p:/g, ''), 10);
+    Object.keys(data).forEach(id => {
+      if (data[id].priority !== priority) {
+        delete data[id];
+      }
+    });
+    return data;
+  }
+
   _filterByAttributes(attr, data = this._data) {
     if (Object.keys(data).length === 0) {
       return data;
@@ -240,6 +250,12 @@ class Taskbook {
         case 'note':
         case 'notes':
           data = this._filterNote(data);
+          break;
+
+        case 'p:1':
+        case 'p:2':
+        case 'p:3':
+          data = this._filterPriority(data, x);
           break;
 
         default:


### PR DESCRIPTION
Resolves #134 

I have added` _filterPriority` function to filter list by priority.
Unfortunately, I have handled equal case right now. I try to implement regex on switch case to catch priority pattern, don't want to duplicate too many cases, but doesn't work.

Does it have any way to handle many cases of priority?
If you have any feedback or suggestion, please comment on this PR.