### PR TITLE
Add support for armhf Snapcraft architecture. Fixes #143

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,6 +13,7 @@ confinement: strict
 architectures:
   - amd64
   - i386
+  - armhf
 
 apps:
   taskbook:


### PR DESCRIPTION
## Description

The following PR introduces support for the `armhf` Snapcraft architecture.