### PR TITLE
Add ability to view tasks by completed date. Fixes #158

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -56,6 +56,10 @@ const cli = meow(help, {
       type: 'boolean',
       alias: 'i'
     },
+    checked: {
+      type: 'boolean',
+      alias: 'k'
+    },
     priority: {
       type: 'boolean',
       alias: 'p'

--- a/index.js
+++ b/index.js
@@ -48,6 +48,11 @@ const taskbookCLI = (input, flags) => {
     return taskbook.displayStats();
   }
 
+  if (flags.checked) {
+    taskbook.displayByCheckedDate();
+    return taskbook.displayStats();
+  }
+
   if (flags.find) {
     return taskbook.findItems(input);
   }

--- a/src/help.js
+++ b/src/help.js
@@ -23,6 +23,7 @@ module.exports = `
       --star, -s         Star/unstar item
       --task, -t         Create task
       --timeline, -i     Display timeline view
+      --checked, -k      Display timeline view based on checked date
       --version, -v      Display installed version
 
     Examples

--- a/src/task.js
+++ b/src/task.js
@@ -5,6 +5,7 @@ class Task extends Item {
   constructor(options = {}) {
     super(options);
     this._isTask = true;
+    this._completedDate = options._completedDate || null;
     this.isComplete = options.isComplete || false;
     this.inProgress = options.inProgress || false;
     this.isStarred = options.isStarred || false;

--- a/src/taskbook.js
+++ b/src/taskbook.js
@@ -86,6 +86,18 @@ class Taskbook {
     return dates;
   }
 
+  _getCompletedDates(data = this._data) {
+    const dates = [];
+
+    for (const id of Object.keys(data)) {
+      if (data[id]._completedDate != null && dates.indexOf(data[id]._completedDate) === -1) {
+        dates.push(data[id]._completedDate);
+      }
+    }
+
+    return dates;
+  }
+
   _getIDs(data = this._data) {
     return Object.keys(data).map(id => parseInt(id, 10));
   }
@@ -292,6 +304,25 @@ class Taskbook {
     return grouped;
   }
 
+  _groupByCompletedDate(data = this._data, dates = this._getCompletedDates()) {
+    const grouped = {};
+    Object.keys(data).forEach(id => {
+      if (data[id].isComplete && data[id]._completedDate != null) {
+        dates.forEach(date => {
+          if (data[id]._completedDate === date) {
+            if (Array.isArray(grouped[date])) {
+              return grouped[date].push(data[id]);
+            }
+
+            grouped[date] = [data[id]];
+            return grouped[date];
+          }
+        });
+      }
+    });
+    return grouped;
+  }
+
   _saveItemToArchive(item) {
     const {_archive} = this;
     const archiveID = this._generateID(_archive);
@@ -341,7 +372,13 @@ class Taskbook {
       if (_data[id]._isTask) {
         _data[id].inProgress = false;
         _data[id].isComplete = !_data[id].isComplete;
-        return _data[id].isComplete ? checked.push(id) : unchecked.push(id);
+        if (_data[id].isComplete) {
+          _data[id]._completedDate = new Date().toDateString();
+          checked.push(id);
+        } else {
+          _data[id]._completedDate = null;
+          unchecked.push(id);
+        }
       }
     });
 
@@ -400,6 +437,10 @@ class Taskbook {
 
   displayByDate() {
     render.displayByDate(this._groupByDate());
+  }
+
+  displayByCheckedDate() {
+    render.displayByDate(this._groupByCompletedDate());
   }
 
   displayStats() {
@@ -543,7 +584,7 @@ class Taskbook {
       render.missingID();
       process.exit(1);
     }
-
+ 
     if (targets.length > 1) {
       render.invalidIDsNumber();
       process.exit(1);


### PR DESCRIPTION
This addresses the issue raised in #158. Currently, taskbook does not track "completed" or "checked" dates, only the date of creation. It was fairly trivial to begin tracking this date, and then to create a timeline view which was grouped on this data.



<img width="484" alt="Screen Shot 2021-06-23 at 9 03 16 AM" src="https://user-images.githubusercontent.com/3732400/123102135-bfedfc00-d402-11eb-8526-f3c85877116a.png">
<img width="493" alt="Screen Shot 2021-06-23 at 9 03 04 AM" src="https://user-images.githubusercontent.com/3732400/123102142-c11f2900-d402-11eb-88cd-bc58be24e5c6.png">
