### PR TITLE
feat: allow custom storage dir overrides

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -79,7 +79,7 @@ const cli = meow(help, {
     clear: {
       type: 'boolean'
     },
-    storageDir: {
+    taskbookDir: {
       type: 'string'
     }
   }

--- a/cli.js
+++ b/cli.js
@@ -78,6 +78,9 @@ const cli = meow(help, {
     },
     clear: {
       type: 'boolean'
+    },
+    storageDir: {
+      type: 'string'
     }
   }
 });

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const Taskbook = require('./src/taskbook');
 
 const taskbookCLI = (input, flags) => {
-  const taskbook = new Taskbook({storageDir: flags.storageDir});
+  const taskbook = new Taskbook({taskbookDir: flags.taskbookDir});
 
   if (flags.archive) {
     return taskbook.displayArchive();

--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 'use strict';
-const taskbook = require('./src/taskbook');
+const Taskbook = require('./src/taskbook');
 
 const taskbookCLI = (input, flags) => {
+  const taskbook = new Taskbook({storageDir: flags.storageDir});
+
   if (flags.archive) {
     return taskbook.displayArchive();
   }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const Taskbook = require('./src/taskbook');
 
 const taskbookCLI = (input, flags) => {
-  const taskbook = new Taskbook({taskbookDir: flags.taskbookDir});
+  const taskbook = new Taskbook(flags);
 
   if (flags.archive) {
     return taskbook.displayArchive();

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,7 @@ Visit the [contributing guidelines](https://github.com/klaudiosinani/taskbook/bl
 - Update notifications
 - Configurable through `~/.taskbook.json`
 - Data stored in JSON file at `~/.taskbook/storage`
+- Data location can be overwritten at runtime
 
 View highlights in a [taskbook board](https://raw.githubusercontent.com/klaudiosinani/taskbook/master/media/highlights.png).
 
@@ -116,6 +117,7 @@ $ tb --help
       --priority, -p     Update priority of task
       --restore, -r      Restore items from archive
       --star, -s         Star/unstar item
+      --taskbook-dir     Define a custom taskbook directory
       --task, -t         Create task
       --timeline, -i     Display timeline view
       --version, -v      Display installed version
@@ -136,6 +138,7 @@ $ tb --help
       $ tb --priority @3 2
       $ tb --restore 4
       $ tb --star 2
+      $ tb --taskbook-dir .custom-taskbook-dir
       $ tb --task @coding @reviews Review PR #42
       $ tb --task @coding Improve documentation
       $ tb --task Make some buttercream
@@ -358,6 +361,20 @@ To search for one of more items, use the `--find`/`-f` option, followed by your 
 
 ```
 $ tb -f documentation
+```
+
+### Runtime taskbook directory override
+
+To override the configured storage location, use the `--taskbook-dir` flag or TASKBOOK_DIR environment variable. While Taskbook is designed to provide a multiple board approach for all of your projects, these options enable alternative use cases. Setup per project storage or run multiple global boards like home and work.
+
+Note, if both the flag and environment variable are present Taskbook will use the flag value.
+
+```
+$ tb --taskbook-dir .custom-taskbook-dir
+```
+
+```
+$ TASKBOOK_DIR=~/hometasks tb
 ```
 
 ## Development

--- a/src/directory.js
+++ b/src/directory.js
@@ -131,10 +131,6 @@ class Directory {
     return typeof input === 'string' && input.trim().length === 0;
   }
 
-  _isPresentString(input) {
-    return this._isStringType(input) && !this._isEmptyString(input);
-  }
-
   _expandDirectory(directory) {
     return directory.replace(/^~(?=$|[\\/])/, os.homedir());
   }

--- a/src/directory.js
+++ b/src/directory.js
@@ -5,7 +5,7 @@ const path = require('node:path');
 const config = require('./config');
 const render = require('./render');
 
-const {join, resolve} = path;
+const { join, resolve } = path;
 
 class Directory {
   _taskbookDirectoryName = '.taskbook';
@@ -16,12 +16,12 @@ class Directory {
   }
 
   get userConfigTaskbookParentDirectory() {
-    const {taskbookDirectory} = config.get();
+    const { taskbookDirectory } = config.get();
     return taskbookDirectory;
   }
 
   get environmentVariableTaskbookParentDirectory() {
-    return process.env.TASKBOOK_DIRECTORY;
+    return process.env.TASKBOOK_DIR;
   }
 
   retrieveTaskbookDirectory(options) {
@@ -48,18 +48,12 @@ class Directory {
   _retrieveTaskbookCustomParentDirectoryOrExit(candidates) {
     const selectedCandidate = this._selectHighestPriorityTaskbookParentDirectory(candidates);
 
-    if (!this._isDefined(selectedCandidate)) {
-      return null;
+    if (!this._isExistingDirectory(selectedCandidate)) {
+      render.invalidCustomAppDir(selectedCandidate);
+      process.exit(1);
     }
 
-    const isValidCandidate = this._isValidTaskbookCustomParentDirectory(selectedCandidate);
-
-    if (isValidCandidate) {
-      return this._parseDirectory(selectedCandidate);
-    }
-
-    render.invalidCustomAppDir(selectedCandidate);
-    process.exit(1);
+    return this._parseDirectory(selectedCandidate);
   }
 
   _retrieveTaskbookParentDirectoryCandidates(options) {
@@ -75,7 +69,7 @@ class Directory {
   }
 
   _filterPresentTaskbookParentDirectoryCandidates(candidates) {
-    return candidates.filter(candidate => this._isDefined(candidate) && this._isStringType(candidate));
+    return candidates.filter(candidate => this._isStringType(candidate));
   }
 
   _selectHighestPriorityTaskbookParentDirectory(candidates) {
@@ -99,10 +93,6 @@ class Directory {
     return fs.existsSync(parsedDirectory);
   }
 
-  _isValidDirectoryFormat(directory) {
-    return this._isStringType(directory);
-  }
-
   _parseDirectory(directory) {
     const expandedDirectory = this._expandDirectory(directory);
     return resolve(expandedDirectory);
@@ -114,14 +104,6 @@ class Directory {
 
   _isStringType(input) {
     return typeof input === 'string';
-  }
-
-  _isEmptyString(directory) {
-    return this._trim(directory).length === 0;
-  }
-
-  _trim(directory) {
-    return directory.trim();
   }
 
   _expandDirectory(directory) {

--- a/src/directory.js
+++ b/src/directory.js
@@ -1,7 +1,7 @@
 'use strict';
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const config = require('./config');
 const render = require('./render');
 

--- a/src/directory.js
+++ b/src/directory.js
@@ -129,4 +129,4 @@ class Directory {
   }
 }
 
-module.exports = Directory;
+module.exports = new Directory();

--- a/src/directory.js
+++ b/src/directory.js
@@ -1,0 +1,132 @@
+'use strict';
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const config = require('./config');
+const render = require('./render');
+
+const {join, resolve} = path;
+
+class Directory {
+  _taskbookDirectoryName = '.taskbook';
+  _userHomeDirectory = os.homedir();
+
+  get taskbookDirectoryName() {
+    return this._taskbookDirectoryName;
+  }
+
+  get userConfigTaskbookParentDirectory() {
+    const {taskbookDirectory} = config.get();
+    return taskbookDirectory;
+  }
+
+  get environmentVariableTaskbookParentDirectory() {
+    return process.env.TASKBOOK_DIRECTORY;
+  }
+
+  retrieveTaskbookDirectory(options) {
+    const parent = this._retrieveTaskbookParentDirectory(options);
+    return this._composeTaskbookDirectory(parent);
+  }
+
+  _retrieveTaskbookParentDirectory(options) {
+    const customTaskbookParentDirectory = this._retrieveTaskbookCustomParentDirectory(options);
+
+    if (customTaskbookParentDirectory) {
+      return customTaskbookParentDirectory;
+    }
+
+    return this._retrieveDefaultTaskbookParentDirectory();
+  }
+
+  _retrieveTaskbookCustomParentDirectory(options) {
+    const candidates = this._retrieveTaskbookParentDirectoryCandidates(options);
+    const presentCandidates = this._filterPresentTaskbookParentDirectoryCandidates(candidates);
+    return this._retrieveTaskbookCustomParentDirectoryOrExit(presentCandidates);
+  }
+
+  _retrieveTaskbookCustomParentDirectoryOrExit(candidates) {
+    const selectedCandidate = this._selectHighestPriorityTaskbookParentDirectory(candidates);
+
+    if (!this._isDefined(selectedCandidate)) {
+      return null;
+    }
+
+    const isValidCandidate = this._isValidTaskbookCustomParentDirectory(selectedCandidate);
+
+    if (isValidCandidate) {
+      return this._parseDirectory(selectedCandidate);
+    }
+
+    render.invalidCustomAppDir(selectedCandidate);
+    process.exit(1);
+  }
+
+  _retrieveTaskbookParentDirectoryCandidates(options) {
+    return [
+      this._getTaskbookParentDirectoryFlagParameter(options),
+      this.environmentVariableTaskbookParentDirectory,
+      this.userConfigTaskbookParentDirectory,
+    ];
+  }
+
+  _getTaskbookParentDirectoryFlagParameter(options) {
+    return options.taskbookDir;
+  }
+
+  _filterPresentTaskbookParentDirectoryCandidates(candidates) {
+    return candidates.filter(candidate => this._isDefined(candidate) && this._isStringType(candidate));
+  }
+
+  _selectHighestPriorityTaskbookParentDirectory(candidates) {
+    return candidates[0];
+  }
+
+  _retrieveDefaultTaskbookParentDirectory() {
+    return this._userHomeDirectory;
+  }
+
+  _composeTaskbookDirectory(parentDirectory) {
+    return join(parentDirectory, this.taskbookDirectoryName);
+  }
+
+  _isValidTaskbookCustomParentDirectory(directory) {
+    return !this._isEmptyString(directory) && this._isExistingDirectory(directory);
+  }
+
+  _isExistingDirectory(directory) {
+    const parsedDirectory = this._parseDirectory(directory);
+    return fs.existsSync(parsedDirectory);
+  }
+
+  _isValidDirectoryFormat(directory) {
+    return this._isStringType(directory);
+  }
+
+  _parseDirectory(directory) {
+    const expandedDirectory = this._expandDirectory(directory);
+    return resolve(expandedDirectory);
+  }
+
+  _isDefined(input) {
+    return input !== undefined && input !== null;
+  }
+
+  _isStringType(input) {
+    return typeof input === 'string';
+  }
+
+  _isEmptyString(directory) {
+    return this._trim(directory).length === 0;
+  }
+
+  _trim(directory) {
+    return directory.trim();
+  }
+
+  _expandDirectory(directory) {
+    return directory.replace(/^~(?=$|[\\/])/, os.homedir());
+  }
+}
+
+module.exports = Directory;

--- a/src/directory.js
+++ b/src/directory.js
@@ -85,7 +85,11 @@ class Directory {
   }
 
   _isValidTaskbookCustomParentDirectory(directory) {
-    return !this._isEmptyString(directory) && this._isExistingDirectory(directory);
+    return (
+      this._isDefined(directory) &&
+      !this._isEmptyString(directory) &&
+      this._isExistingDirectory(directory)
+    );
   }
 
   _isExistingDirectory(directory) {
@@ -106,6 +110,10 @@ class Directory {
     return typeof input === 'string';
   }
 
+  _isEmptyString(input) {
+    return typeof input === 'string' && input.trim().length === 0;
+  }
+  
   _expandDirectory(directory) {
     return directory.replace(/^~(?=$|[\\/])/, os.homedir());
   }

--- a/src/directory.js
+++ b/src/directory.js
@@ -64,7 +64,7 @@ class Directory {
   }
 
   _getTaskbookDirFlagCandidate(options) {
-    if (!Object.prototype.hasOwnProperty.call(options, 'taskbookDir')) {
+    if (!Object.hasOwn(options, 'taskbookDir')) {
       return undefined;
     }
 

--- a/src/directory.js
+++ b/src/directory.js
@@ -70,7 +70,7 @@ class Directory {
 
     const { taskbookDir } = options;
 
-    if (!this._isStringType(taskbookDir) || this._isEmptyString(taskbookDir)) {
+    if (!this._isPresentString(taskbookDir)) {
       render.missingTaskbookDirFlagValue();
       process.exit(1);
     }
@@ -129,6 +129,10 @@ class Directory {
 
   _isEmptyString(input) {
     return typeof input === 'string' && input.trim().length === 0;
+  }
+
+  _isPresentString(input) {
+    return this._isStringType(input) && !this._isEmptyString(input);
   }
 
   _expandDirectory(directory) {

--- a/src/directory.js
+++ b/src/directory.js
@@ -25,76 +25,93 @@ class Directory {
   }
 
   retrieveTaskbookDirectory(options) {
-    const parent = this._retrieveTaskbookParentDirectory(options);
-    return this._composeTaskbookDirectory(parent);
-  }
+    const customDirectory = this._resolveCustomTaskbookDirectory(options);
 
-  _retrieveTaskbookParentDirectory(options) {
-    const customTaskbookParentDirectory = this._retrieveTaskbookCustomParentDirectory(options);
-
-    if (customTaskbookParentDirectory) {
-      return customTaskbookParentDirectory;
+    if (customDirectory) {
+      return customDirectory;
     }
 
-    return this._retrieveDefaultTaskbookParentDirectory();
+    return this._composeTaskbookDirectory(this._userHomeDirectory);
   }
 
-  _retrieveTaskbookCustomParentDirectory(options) {
-    const candidates = this._retrieveTaskbookParentDirectoryCandidates(options);
-    const presentCandidates = this._filterPresentTaskbookParentDirectoryCandidates(candidates);
-    return this._retrieveTaskbookCustomParentDirectoryOrExit(presentCandidates);
-  }
+  _resolveCustomTaskbookDirectory(options) {
+    const candidate = this._selectCustomDirectoryCandidate(options);
 
-  _retrieveTaskbookCustomParentDirectoryOrExit(candidates) {
-    const selectedCandidate = this._selectHighestPriorityTaskbookParentDirectory(candidates);
-
-    if (!this._isExistingDirectory(selectedCandidate)) {
-      render.invalidCustomAppDir(selectedCandidate);
-      process.exit(1);
+    if (!candidate) {
+      return undefined;
     }
 
-    return this._parseDirectory(selectedCandidate);
+    const resolvedCandidate = this._parseDirectory(candidate);
+
+    if (this._isTaskbookDirectoryPath(resolvedCandidate)) {
+      const parentDirectory = path.dirname(resolvedCandidate);
+      this._assertDirectoryExists(parentDirectory, candidate);
+      return resolvedCandidate;
+    }
+
+    this._assertDirectoryExists(resolvedCandidate, candidate);
+    return this._composeTaskbookDirectory(resolvedCandidate);
   }
 
-  _retrieveTaskbookParentDirectoryCandidates(options) {
-    return [
-      this._getTaskbookParentDirectoryFlagParameter(options),
+  _selectCustomDirectoryCandidate(options) {
+    const candidates = [
+      this._getTaskbookDirFlagCandidate(options),
       this.environmentVariableTaskbookParentDirectory,
       this.userConfigTaskbookParentDirectory,
     ];
+
+    return candidates.find(candidate => this._isPresentString(candidate));
   }
 
-  _getTaskbookParentDirectoryFlagParameter(options) {
-    return options.taskbookDir;
+  _getTaskbookDirFlagCandidate(options) {
+    if (!Object.prototype.hasOwnProperty.call(options, 'taskbookDir')) {
+      return undefined;
+    }
+
+    const { taskbookDir } = options;
+
+    if (!this._isStringType(taskbookDir) || this._isEmptyString(taskbookDir)) {
+      render.missingTaskbookDirFlagValue();
+      process.exit(1);
+    }
+
+    return taskbookDir;
   }
 
-  _filterPresentTaskbookParentDirectoryCandidates(candidates) {
-    return candidates.filter(candidate => this._isStringType(candidate));
+  _isPresentString(value) {
+    return this._isStringType(value) && !this._isEmptyString(value);
   }
 
-  _selectHighestPriorityTaskbookParentDirectory(candidates) {
-    return candidates[0];
-  }
+  _assertDirectoryExists(directory, displayPath = directory) {
+    if (this._isExistingDirectory(directory)) {
+      return;
+    }
 
-  _retrieveDefaultTaskbookParentDirectory() {
-    return this._userHomeDirectory;
+    render.invalidCustomAppDir(
+      this._formatInvalidTaskbookDirectoryCandidate(displayPath),
+    );
+    process.exit(1);
   }
 
   _composeTaskbookDirectory(parentDirectory) {
     return join(parentDirectory, this.taskbookDirectoryName);
   }
 
-  _isValidTaskbookCustomParentDirectory(directory) {
-    return (
-      this._isDefined(directory) &&
-      !this._isEmptyString(directory) &&
-      this._isExistingDirectory(directory)
-    );
+  _isTaskbookDirectoryPath(directory) {
+    return path.basename(directory) === this.taskbookDirectoryName;
   }
 
   _isExistingDirectory(directory) {
     const parsedDirectory = this._parseDirectory(directory);
     return fs.existsSync(parsedDirectory);
+  }
+
+  _formatInvalidTaskbookDirectoryCandidate(candidate) {
+    if (!this._isDefined(candidate) || this._isEmptyString(candidate)) {
+      return '""';
+    }
+
+    return candidate;
   }
 
   _parseDirectory(directory) {
@@ -113,7 +130,7 @@ class Directory {
   _isEmptyString(input) {
     return typeof input === 'string' && input.trim().length === 0;
   }
-  
+
   _expandDirectory(directory) {
     return directory.replace(/^~(?=$|[\\/])/, os.homedir());
   }

--- a/src/help.js
+++ b/src/help.js
@@ -21,7 +21,7 @@ module.exports = `
       --priority, -p     Update priority of task
       --restore, -r      Restore items from archive
       --star, -s         Star/unstar item
-      --storage-dir      Use custom storage directory
+      --taskbook-dir     Define a custom taskbook directory
       --task, -t         Create task
       --timeline, -i     Display timeline view
       --version, -v      Display installed version

--- a/src/help.js
+++ b/src/help.js
@@ -21,6 +21,7 @@ module.exports = `
       --priority, -p     Update priority of task
       --restore, -r      Restore items from archive
       --star, -s         Star/unstar item
+      --storage-dir      Use custom storage directory
       --task, -t         Create task
       --timeline, -i     Display timeline view
       --version, -v      Display installed version

--- a/src/render.js
+++ b/src/render.js
@@ -200,6 +200,12 @@ class Render {
     error({prefix, message, suffix});
   }
 
+  missingTaskbookDirFlagValue() {
+    const message =
+      'Please provide a value for --taskbook-dir or remove the flag.';
+    error({prefix: '\n ', message});
+  }
+
   invalidID(id) {
     const [prefix, suffix] = ['\n', grey(id)];
     const message = 'Unable to find item with id:';

--- a/src/storage.js
+++ b/src/storage.js
@@ -3,13 +3,12 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
-const Directory = require('./directory');
+const directory = require('./directory');
 
 const {basename, join} = path;
 
 class Storage {
   constructor(options = {}) {
-    const directory = new Directory();
     this._mainAppDir = directory.retrieveTaskbookDirectory(options);
     this._storageDir = join(this._mainAppDir, 'storage');
     this._archiveDir = join(this._mainAppDir, 'archive');

--- a/src/storage.js
+++ b/src/storage.js
@@ -2,16 +2,15 @@
 'use strict';
 const crypto = require('crypto');
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
-const config = require('./config');
-const render = require('./render');
+const Directory = require('./directory');
 
-const {basename, dirname, join, resolve} = path;
+const {basename, join} = path;
 
 class Storage {
   constructor(options = {}) {
-    this._mainAppDir = this._resolveMainAppDir(options.storageDir);
+    const directory = new Directory();
+    this._mainAppDir = directory.retrieveTaskbookDirectory(options);
     this._storageDir = join(this._mainAppDir, 'storage');
     this._archiveDir = join(this._mainAppDir, 'archive');
     this._tempDir = join(this._mainAppDir, '.temp');
@@ -19,65 +18,6 @@ class Storage {
     this._mainStorageFile = join(this._storageDir, 'storage.json');
 
     this._ensureDirectories();
-  }
-
-  _resolveMainAppDir(overrideDir) {
-    const sources = [
-      {value: overrideDir, enforce: true},
-      {value: process.env.TASKBOOK_DIR, enforce: true},
-      {value: this._getConfiguredDir(), enforce: true},
-      {value: os.homedir(), enforce: true}
-    ];
-
-    for (const {value, enforce} of sources) {
-      const formatted = this._formatDir(value);
-
-      if (!formatted) {
-        continue;
-      }
-
-      const {baseDir, mainDir} = this._deriveDirs(formatted);
-
-      if (!fs.existsSync(baseDir)) {
-        if (enforce) {
-          render.invalidCustomAppDir(baseDir);
-          process.exit(1);
-        }
-
-        continue;
-      }
-
-      return mainDir;
-    }
-
-    return join(os.homedir(), '.taskbook');
-  }
-
-  _getConfiguredDir() {
-    const {taskbookDirectory} = config.get();
-    return (typeof taskbookDirectory === 'string' && taskbookDirectory.trim().length > 0) ? taskbookDirectory : null;
-  }
-
-  _formatDir(dir) {
-    if (typeof dir !== 'string') {
-      return null;
-    }
-
-    const trimmed = dir.trim();
-
-    if (trimmed.length === 0) {
-      return null;
-    }
-
-    const expanded = trimmed.replace(/^~(?=$|[\\/])/, os.homedir());
-    return resolve(expanded);
-  }
-
-  _deriveDirs(dir) {
-    const isTaskbookDir = basename(dir) === '.taskbook';
-    const baseDir = isTaskbookDir ? dirname(dir) : dir;
-    const mainDir = isTaskbookDir ? dir : join(dir, '.taskbook');
-    return {baseDir, mainDir};
   }
 
   _ensureMainAppDir() {

--- a/src/storage.js
+++ b/src/storage.js
@@ -7,10 +7,11 @@ const path = require('path');
 const config = require('./config');
 const render = require('./render');
 
-const {basename, join} = path;
+const {basename, dirname, join, resolve} = path;
 
 class Storage {
-  constructor() {
+  constructor(options = {}) {
+    this._mainAppDir = this._resolveMainAppDir(options.storageDir);
     this._storageDir = join(this._mainAppDir, 'storage');
     this._archiveDir = join(this._mainAppDir, 'archive');
     this._tempDir = join(this._mainAppDir, '.temp');
@@ -20,20 +21,63 @@ class Storage {
     this._ensureDirectories();
   }
 
-  get _mainAppDir() {
+  _resolveMainAppDir(overrideDir) {
+    const sources = [
+      {value: overrideDir, enforce: true},
+      {value: process.env.TASKBOOK_DIR, enforce: true},
+      {value: this._getConfiguredDir(), enforce: true},
+      {value: os.homedir(), enforce: true}
+    ];
+
+    for (const {value, enforce} of sources) {
+      const formatted = this._formatDir(value);
+
+      if (!formatted) {
+        continue;
+      }
+
+      const {baseDir, mainDir} = this._deriveDirs(formatted);
+
+      if (!fs.existsSync(baseDir)) {
+        if (enforce) {
+          render.invalidCustomAppDir(baseDir);
+          process.exit(1);
+        }
+
+        continue;
+      }
+
+      return mainDir;
+    }
+
+    return join(os.homedir(), '.taskbook');
+  }
+
+  _getConfiguredDir() {
     const {taskbookDirectory} = config.get();
-    const defaultAppDirectory = join(os.homedir(), '.taskbook');
+    return (typeof taskbookDirectory === 'string' && taskbookDirectory.trim().length > 0) ? taskbookDirectory : null;
+  }
 
-    if (!taskbookDirectory) {
-      return defaultAppDirectory;
+  _formatDir(dir) {
+    if (typeof dir !== 'string') {
+      return null;
     }
 
-    if (!fs.existsSync(taskbookDirectory)) {
-      render.invalidCustomAppDir(taskbookDirectory);
-      process.exit(1);
+    const trimmed = dir.trim();
+
+    if (trimmed.length === 0) {
+      return null;
     }
 
-    return join(taskbookDirectory, '.taskbook');
+    const expanded = trimmed.replace(/^~(?=$|[\\/])/, os.homedir());
+    return resolve(expanded);
+  }
+
+  _deriveDirs(dir) {
+    const isTaskbookDir = basename(dir) === '.taskbook';
+    const baseDir = isTaskbookDir ? dirname(dir) : dir;
+    const mainDir = isTaskbookDir ? dir : join(dir, '.taskbook');
+    return {baseDir, mainDir};
   }
 
   _ensureMainAppDir() {

--- a/src/taskbook.js
+++ b/src/taskbook.js
@@ -7,8 +7,8 @@ const Storage = require('./storage');
 const render = require('./render');
 
 class Taskbook {
-  constructor() {
-    this._storage = new Storage();
+  constructor(options = {}) {
+    this._storage = new Storage(options);
   }
 
   get _archive() {
@@ -576,4 +576,4 @@ class Taskbook {
   }
 }
 
-module.exports = new Taskbook();
+module.exports = Taskbook;


### PR DESCRIPTION
The strategy is --storage-dir flag, then TASKBOOK_DIR, then config, then default locations.

This pr reorganizes things just a bit and adds support for the flag and ENV overrides.

I apologize for the architectural rework required to support this feature. The changes convert taskbook from a singleton export to a class that can be instantiated with options. While this is a breaking change at the module level, it does not affect end-users or CLI behavior—existing workflows continue to work exactly as before.

I really love your taskbook ux and it's really nice to use per project, especially with coding agents.

I'm using this alias and it rocks, but i didn't want to propose this change in the core because it work break tb for existing users if they happened to end up in a dir with a .taskbook folder

      ## Shell Alias for Smooth Workflow
      ```bash
      tb() {
        if [ -d "./.taskbook" ]; then
          command tb --storage-dir ./.taskbook "$@"
        else
          command tb "$@"
        fi
      }
      ```
